### PR TITLE
Add quotes around paths in shell commands

### DIFF
--- a/cacheDependencyManagers/cacheDependencyManager.js
+++ b/cacheDependencyManagers/cacheDependencyManager.js
@@ -55,7 +55,7 @@ CacheDependencyManager.prototype.archiveDependencies = function (cacheDirectory,
   shell.mkdir('-p', cacheDirectory);
 
   // Now archive installed directory
-  if (shell.exec('tar -zcf ' + cachePath + ' -C ' + installedDirectory + ' .').code !== 0) {
+  if (shell.exec('tar -zcf "' + cachePath + '" -C "' + installedDirectory + '" .').code !== 0) {
     error = 'error tar-ing ' + installedDirectory;
     this.cacheLogError(error);
     shell.rm(cachePath);
@@ -69,7 +69,7 @@ CacheDependencyManager.prototype.extractDependencies = function (cachePath) {
   var error = null;
   var installedDirectory = getAbsolutePath(this.config.installDirectory);
   this.cacheLogInfo('clearing installed dependencies at ' + installedDirectory);
-  var removeExitCode = shell.exec('rm -rf ' + installedDirectory).code;
+  var removeExitCode = shell.exec('rm -rf "' + installedDirectory + '"').code;
   if (removeExitCode !== 0) {
     error = 'error removing installed dependencies at ' + installedDirectory;
     this.cacheLogError(error);
@@ -80,7 +80,7 @@ CacheDependencyManager.prototype.extractDependencies = function (cachePath) {
     shell.mkdir('-p', installedDirectory);
 
     this.cacheLogInfo('extracting dependencies from ' + cachePath);
-    var tarExtractCode = shell.exec('tar -zxf ' + cachePath + ' -C ' + installedDirectory).code;
+    var tarExtractCode = shell.exec('tar -zxf "' + cachePath + '" -C "' + installedDirectory + '"').code;
     if (tarExtractCode !== 0) {
       error = 'error untar-ing ' + cachePath;
       this.cacheLogError(error);


### PR DESCRIPTION
npm-cache was not playing nice for paths with spaces in them, so we should wrap quotes around the paths referenced by shell commands.

Full disclosure, I copied the code from this guy's commit, but wanted to issue a pull request to ensure this made it into master:

https://github.com/thebrux/npm-cache/commit/62bc6ea828f468c46c3e6e936f588fd462fcc5e4