### PR TITLE
Switch to non-deprecated md5 dependency

### DIFF
--- a/cacheDependencyManagers/cacheDependencyManager.js
+++ b/cacheDependencyManagers/cacheDependencyManager.js
@@ -3,7 +3,7 @@
 var fs = require('fs');
 var path = require('path');
 var logger = require('../util/logger');
-var md5 = require('MD5');
+var md5 = require('md5');
 var shell = require('shelljs');
 
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/swarajban/npm-cache",
   "dependencies": {
-    "MD5": "1.2.1",
+    "md5": "2.0.0",
     "async": "0.9.0",
     "glob": "5.0.10",
     "lodash": "3.5.0",


### PR DESCRIPTION
Appears there were 2 md5 modules, essentially the same. MD5 is deprecated though, md5 is what should be used.

https://github.com/pvorb/node-md5#versions