### PR TITLE
Ignore version numbers

### DIFF
--- a/cacheDependencyManagers/bowerConfig.js
+++ b/cacheDependencyManagers/bowerConfig.js
@@ -25,7 +25,6 @@ function getFileHash(filePath) {
   return md5(JSON.stringify({
     dependencies: json.dependencies,
     devDependencies: json.devDependencies,
-    devDependencies: json.devDependencies,
     overrides: json.overrides
   }));
 };

--- a/cacheDependencyManagers/bowerConfig.js
+++ b/cacheDependencyManagers/bowerConfig.js
@@ -20,6 +20,16 @@ var getBowerInstallDirectory = function () {
 };
 
 
+function getFileHash(filePath) {
+  var json = JSON.parse(fs.readFileSync(filePath));
+  return md5(JSON.stringify({
+    dependencies: json.dependencies,
+    devDependencies: json.devDependencies,
+    devDependencies: json.devDependencies,
+    overrides: json.overrides
+  }));
+};
+
 module.exports = {
   cliName: 'bower',
   getCliVersion: function getNpmVersion () {
@@ -27,5 +37,6 @@ module.exports = {
   },
   configPath: path.resolve(process.cwd(), 'bower.json'),
   installDirectory: getBowerInstallDirectory(),
-  installCommand: 'bower install'
+  installCommand: 'bower install',
+  getFileHash: getFileHash
 };

--- a/cacheDependencyManagers/cacheDependencyManager.js
+++ b/cacheDependencyManagers/cacheDependencyManager.js
@@ -11,12 +11,6 @@ function CacheDependencyManager (config) {
   this.config = config;
 }
 
-var getFileHash = function (filePath) {
-  var file = fs.readFileSync(filePath);
-  file = file.replace(/\"version"\:\s*"[0-9.]+",/, '');
-  return md5(file);
-};
-
 // Given a path relative to process' current working directory,
 // returns a normalized absolute path
 var getAbsolutePath = function (relativePath) {
@@ -116,7 +110,7 @@ CacheDependencyManager.prototype.loadDependencies = function (callback) {
 
 
   // Get hash of dependency config file
-  var hash = getFileHash(this.config.configPath);
+  var hash = this.config.getFileHash(this.config.configPath);
   this.cacheLogInfo('hash of ' + this.config.configPath + ': ' + hash);
   // cachePath is absolute path to where local cache of dependencies is located
   var cacheDirectory = path.resolve(this.config.cacheDirectory, this.config.cliName, this.config.getCliVersion());

--- a/cacheDependencyManagers/cacheDependencyManager.js
+++ b/cacheDependencyManagers/cacheDependencyManager.js
@@ -13,6 +13,7 @@ function CacheDependencyManager (config) {
 
 var getFileHash = function (filePath) {
   var file = fs.readFileSync(filePath);
+  file = file.replace(/\"version"\:\s*"[0-9.]+",/, '');
   return md5(file);
 };
 

--- a/cacheDependencyManagers/composerConfig.js
+++ b/cacheDependencyManagers/composerConfig.js
@@ -46,8 +46,8 @@ var getCliVersion = function () {
 function getFileHash(filePath) {
   var json = JSON.parse(fs.readFileSync(filePath));
   return md5(JSON.stringify({
-    packages: json.packages,
-    packagesDev: json['packages-dev']
+    packages: json.require,
+    packagesDev: json['require-dev']
   }));
 };
 

--- a/cacheDependencyManagers/composerConfig.js
+++ b/cacheDependencyManagers/composerConfig.js
@@ -43,11 +43,19 @@ var getCliVersion = function () {
   return version;
 };
 
+function getFileHash(filePath) {
+  var json = JSON.parse(fs.readFileSync(filePath));
+  return md5(JSON.stringify({
+    packages: json.packages,
+    packagesDev: json['packages-dev']
+  }));
+};
 
 module.exports = {
   cliName: 'composer',
   getCliVersion: getCliVersion,
   configPath: composerFilePath,
   installDirectory: getComposerInstallDirectory(),
-  installCommand: 'composer install'
+  installCommand: 'composer install',
+  getFileHash: getFileHash
 };

--- a/cacheDependencyManagers/npmConfig.js
+++ b/cacheDependencyManagers/npmConfig.js
@@ -20,6 +20,13 @@ var getNpmConfigPath = function () {
   }
 };
 
+function getFileHash(filePath) {
+  var json = JSON.parse(fs.readFileSync(filePath));
+  return md5(JSON.stringify({
+    dependencies: json.dependencies,
+    devDependencies: json.devDependencies
+  }));
+};
 
 module.exports = {
   cliName: 'npm',
@@ -28,5 +35,6 @@ module.exports = {
   },
   configPath: getNpmConfigPath(),
   installDirectory: 'node_modules',
-  installCommand: 'npm install'
+  installCommand: 'npm install',
+  getFileHash: getFileHash
 };


### PR DESCRIPTION
Between two releases version number should be ignored.

When you do a npm version patch or any npm version * but you don't change dependencies, a new file hash is generated and a new install is being run.

This makes new cache, and therefore a slower install.
