### PR TITLE
error on archiving if no dependencies

### DIFF
--- a/cacheDependencyManagers/cacheDependencyManager.js
+++ b/cacheDependencyManagers/cacheDependencyManager.js
@@ -45,6 +45,11 @@ CacheDependencyManager.prototype.archiveDependencies = function (cacheDirectory,
   var installedDirectory = getAbsolutePath(this.config.installDirectory);
   this.cacheLogInfo('archiving dependencies from ' + installedDirectory);
 
+  if (!fs.existsSync(installedDirectory)) {
+	   this.cacheLogInfo('skipping archive. Install directory does not exist.');
+	   return error;
+  }
+
   // Make sure cache directory is created
   shell.mkdir('-p', cacheDirectory);
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "local"
   ],
   "author": "swaraj",
+  "contributors": [{
+	  "name": "Aaron Nordyke",
+	  "email": "aaron.nordyke@gmail.com"
+  }],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/swarajban/npm-cache/issues"


### PR DESCRIPTION
If `package.json` or `bower.json` don't have dependencies, `npm-cache install` errors when it tries to archive the non-existent dependencies.  This pull request skips the archive for those situations.