### PR TITLE
Fix: Quote directory paths to allow for spaces

### DIFF
--- a/cacheDependencyManagers/cacheDependencyManager.js
+++ b/cacheDependencyManagers/cacheDependencyManager.js
@@ -49,7 +49,7 @@ CacheDependencyManager.prototype.archiveDependencies = function (cacheDirectory,
   shell.mkdir('-p', cacheDirectory);
 
   // Now archive installed directory
-  if (shell.exec('tar -zcf ' + cachePath + ' -C ' + installedDirectory + ' .').code !== 0) {
+  if (shell.exec('tar -zcf "' + cachePath + '" -C "' + installedDirectory + '" .').code !== 0) {
     error = 'error tar-ing ' + installedDirectory;
     this.cacheLogError(error);
     shell.rm(cachePath);
@@ -74,7 +74,7 @@ CacheDependencyManager.prototype.extractDependencies = function (cachePath) {
     shell.mkdir('-p', installedDirectory);
 
     this.cacheLogInfo('extracting dependencies from ' + cachePath);
-    var tarExtractCode = shell.exec('tar -zxf ' + cachePath + ' -C ' + installedDirectory).code;
+    var tarExtractCode = shell.exec('tar -zxf "' + cachePath + '" -C "' + installedDirectory + '"').code;
     if (tarExtractCode !== 0) {
       error = 'error untar-ing ' + cachePath;
       this.cacheLogError(error);


### PR DESCRIPTION
With this fix it allows for `/path/to/some - space/directory`