### PR TITLE
Changed `rm -rf` to be cross-platform

### DIFF
--- a/cacheDependencyManagers/cacheDependencyManager.js
+++ b/cacheDependencyManagers/cacheDependencyManager.js
@@ -68,9 +68,10 @@ CacheDependencyManager.prototype.extractDependencies = function (cachePath) {
   var error = null;
   var installedDirectory = getAbsolutePath(this.config.installDirectory);
   this.cacheLogInfo('clearing installed dependencies at ' + installedDirectory);
-  var removeExitCode = shell.exec('rm -rf "' + installedDirectory + '"').code;
-  if (removeExitCode !== 0) {
-    error = 'error removing installed dependencies at ' + installedDirectory;
+  shell.rm('-rf', installedDirectory);
+  var removeExitCode = shell.error();
+  if (removeExitCode) {
+    error = 'error removing installed dependencies at ' + installedDirectory + ': ' + removeExitCode;
     this.cacheLogError(error);
   } else {
     this.cacheLogInfo('...cleared');


### PR DESCRIPTION
Using the shelljs implementation instead of shell.exec().

Introduced as part of the fix for #5, this caused issues on Windows, see issue #4 for one report about this.