### PR TITLE
Add NPM_CACHE_DIR env support

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ var main = function () {
     .help('clear cache directory');
 
   parser.option('cacheDirectory', {
-    default: path.resolve(process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE, '.package_cache'),
+    default: process.env.NPM_CACHE_DIR || path.resolve(process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE, '.package_cache'),
     abbr: 'c',
     help: 'directory where dependencies will be cached'
   });


### PR DESCRIPTION
This adds the ability to set the nom-cache directory based on an environment variable, for cases such as CI servers etc where you usually want to set it system-wide.