### PR TITLE
Use node-tar instead of tar.gz

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,13 @@
   "homepage": "https://github.com/swarajban/npm-cache",
   "dependencies": {
     "async": "1.5.0",
-    "decompress": "^3.0.0",
     "fs-extra": "^0.26.2",
     "glob": "6.0.1",
     "lodash": "3.10.1",
     "md5": "2.0.0",
     "nomnom": "1.8.1",
     "shelljs": "0.5.3",
-    "tar.gz": "1.0.2",
+    "tar": "^2.2.1",
     "which": "^1.2.0"
   },
   "preferGlobal": true,


### PR DESCRIPTION
In order to fix https://github.com/swarajban/npm-cache/issues/33 use [node-tar](https://github.com/npm/node-tar) instead of [decompress](https://github.com/kevva/decompress) and [tar.gz](https://github.com/alanhoff/node-tar.gz).