### PR TITLE
add jspm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 npm-cache
 =========
 
-`npm-cache` is a command line utility that caches dependencies installed via `npm`, `bower`, and `composer`.
+`npm-cache` is a command line utility that caches dependencies installed via `npm`, `bower`, `jspm` and `composer`.
 
 It is useful for build processes that run `[npm|bower|composer] install` every time as part of their 
 build process. Since dependencies don't change often, this often means slower build times. `npm-cache`
@@ -9,7 +9,7 @@ helps alleviate this problem by caching previously installed dependencies on the
 `npm-cache` can be a drop-in replacement for any build script that runs `[npm|bower|composer] install`. 
 
 ## How it Works
-When you run `npm-cache install [npm|bower|composer]`, it first looks for `package.json`, `bower.json`,
+When you run `npm-cache install [npm|bower|jspm|composer]`, it first looks for `package.json`, `bower.json`,
 or `composer.json` in the current working directory depending on which dependency manager is requested.
 It then calculates the MD5 hash of the configuration file and looks for a filed named 
 <MD5 of config.json>.tar.gz in the cache directory ($HOME/.package_cache by default). If the file does not

--- a/cacheDependencyManagers/cacheDependencyManager.js
+++ b/cacheDependencyManagers/cacheDependencyManager.js
@@ -22,6 +22,14 @@ var getAbsolutePath = function (relativePath) {
   return path.resolve(process.cwd(), relativePath);
 };
 
+var getFileBackupPath = function (installedDirectory) {
+  return path.join(installedDirectory, '.npm-cache');
+};
+
+var getFileBackupFilename = function (file) {
+  return path.basename(file) + '_' + md5(file);
+};
+
 CacheDependencyManager.prototype.cacheLogInfo = function (message) {
   logger.logInfo('[' + this.config.cliName + '] ' + message);
 };
@@ -45,16 +53,47 @@ CacheDependencyManager.prototype.installDependencies = function () {
   return error;
 };
 
+CacheDependencyManager.prototype.backupFile = function (backupPath, file) {
+  var sourceFile = getAbsolutePath(file);
+  var backupFilename = getFileBackupFilename(file);
+  var backupFile = path.join(backupPath, backupFilename);
+  if (!fs.existsSync(sourceFile)) {
+    this.cacheLogError('backup file [file not found]:' + file);
+    return;
+  }
+
+  fs.mkdirsSync(backupPath);
+  fs.copySync(sourceFile, backupFile);
+  this.cacheLogInfo('backup file: ' + file);
+};
+
+CacheDependencyManager.prototype.restoreFile = function (backupPath, file) {
+  var sourceFile = getAbsolutePath(file);
+  var backupFilename = getFileBackupFilename(file);
+  var backupFile = path.join(backupPath, backupFilename);
+  if (!fs.existsSync(backupFile)) {
+    this.cacheLogError('restore file [file not found]:' + file);
+    return;
+  }
+
+  fs.copySync(backupFile, sourceFile);
+  this.cacheLogInfo('restore file: ' + file);
+};
 
 CacheDependencyManager.prototype.archiveDependencies = function (cacheDirectory, cachePath, callback) {
   var self = this;
   var error = null;
   var installedDirectory = getAbsolutePath(this.config.installDirectory);
+  var fileBackupDirectory = getFileBackupPath(installedDirectory);
   this.cacheLogInfo('archiving dependencies from ' + installedDirectory);
 
   if (!fs.existsSync(installedDirectory)) {
     this.cacheLogInfo('skipping archive. Install directory does not exist.');
     return error;
+  }
+
+  if (this.config.addToArchiveAndRestore) {
+    this.backupFile(fileBackupDirectory, this.config.addToArchiveAndRestore);
   }
 
   // Make sure cache directory is created
@@ -64,12 +103,20 @@ CacheDependencyManager.prototype.archiveDependencies = function (cacheDirectory,
 
   function onError(error) {
     self.cacheLogError('error tar-ing ' + installedDirectory + ' :' + error);
+    onFinally();
     callback(error);
   }
 
   function onEnd() {
     self.cacheLogInfo('installed and archived dependencies');
+    onFinally();
     callback();
+  }
+
+  function onFinally() {
+    if (fs.existsSync(fileBackupDirectory)) {
+      fs.removeSync(fileBackupDirectory);
+    }
   }
 
   var packer = tar.Pack({ noProprietary: true })
@@ -85,6 +132,8 @@ CacheDependencyManager.prototype.archiveDependencies = function (cacheDirectory,
 CacheDependencyManager.prototype.extractDependencies = function (cachePath, callback) {
   var self = this;
   var installDirectory = getAbsolutePath(this.config.installDirectory);
+  var fileBackupDirectory = getFileBackupPath(installDirectory);
+  var targetPath = path.dirname(installDirectory);
   this.cacheLogInfo('clearing installed dependencies at ' + installDirectory);
   fs.removeSync(installDirectory);
   this.cacheLogInfo('...cleared');
@@ -95,11 +144,15 @@ CacheDependencyManager.prototype.extractDependencies = function (cachePath, call
     callback(error);
   }
   function onEnd() {
+    if (self.config.addToArchiveAndRestore) {
+      self.restoreFile(fileBackupDirectory, self.config.addToArchiveAndRestore);
+      fs.removeSync(fileBackupDirectory);
+    }
     self.cacheLogInfo('done extracting');
     callback();
   }
 
-  var extractor = tar.Extract({path: process.cwd()})
+  var extractor = tar.Extract({path: targetPath})
                      .on('error', onError)
                      .on('end', onEnd);
 

--- a/cacheDependencyManagers/jspmConfig.js
+++ b/cacheDependencyManagers/jspmConfig.js
@@ -1,0 +1,108 @@
+'use strict';
+
+var path = require('path');
+var shell = require('shelljs');
+var fs = require('fs');
+var md5 = require('md5');
+var logger = require('../util/logger');
+
+// call these two upfront so log messages emitted by them only show up once
+var configFile = getConfigFile();
+var installDirectory = getInstallDirectory();
+
+/**
+ * @param {string} filename
+ * @returns {string}
+ */
+function getProjectFileContents(filename) {
+    var file = path.resolve(process.cwd(), filename);
+    return fs.readFileSync(file);
+}
+
+/**
+ * @returns {{
+ *   jspm?:{
+ *     configFile?:string,
+ *     directories?:{
+ *       baseURL?:string,
+ *       packages?:string
+ *     }
+ *   }
+ * }}
+ */
+function getPackageJson() {
+    return JSON.parse(getProjectFileContents('package.json'));
+}
+
+/**
+ * @returns {string} default install directory or override from package.json (packages or baseURL)
+ */
+function getInstallDirectory() {
+    var jspm = getPackageJson().jspm;
+    var defaultPath = 'jspm_packages';
+
+    if (jspm && jspm.directories && jspm.directories.packages) {
+        var configPath = jspm.directories.packages;
+        logger.logInfo('[jspm] jspm_packages located at ' + configPath + ' per package.json jspm.directories.packages');
+        return configPath;
+    }
+
+    if (jspm && jspm.directories && jspm.directories.baseURL) {
+        var baseUrlPath = path.join(jspm.directories.baseURL, defaultPath);
+        logger.logInfo('[jspm] jspm_packages located at ' + baseUrlPath + ' per package.json jspm.directories.baseURL');
+        return baseUrlPath;
+    }
+
+    return defaultPath;
+}
+
+/**
+ * @returns {string} default config file or override from package.json (configFile or baseURL)
+ */
+function getConfigFile() {
+    var jspm = getPackageJson().jspm;
+    var defaultFile = 'config.js';
+
+    if (jspm && jspm.configFile) {
+        var configFile = jspm.configFile;
+        logger.logInfo('[jspm] config located at ' + configFile + ' per package.json jspm.configFile');
+        return configFile;
+    }
+
+    if (jspm && jspm.directories && jspm.directories.baseURL) {
+        var baseUrlFile = path.join(jspm.directories.baseURL, defaultFile);
+        logger.logInfo('[jspm] config located at ' + baseUrlFile + ' per package.json jspm.directories.baseURL');
+        return baseUrlFile;
+    }
+
+    return defaultFile;
+}
+
+/**
+ * @returns {string}
+ */
+function getJspmVersion() {
+    var rawMultilineOutput = shell.exec('jspm --version', {silent: true}).output;
+    var version = rawMultilineOutput.split('\n')[0] || 'UnknownVersion';
+    return version.trim();
+}
+
+/**
+ * @returns {string} md5 from jspm config file contents
+ */
+function getConfigurationHash() {
+    return md5(JSON.stringify({
+        'package.json => jspm': getPackageJson().jspm,
+        'config.js': getProjectFileContents(configFile)
+    }));
+}
+
+module.exports = {
+    cliName: 'jspm',
+    getCliVersion: getJspmVersion,
+    configPath: configFile,
+    installDirectory: installDirectory,
+    addToArchiveAndRestore: configFile,
+    installCommand: 'jspm install',
+    getFileHash: getConfigurationHash
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cache",
     "install",
     "bower",
+    "jspm",
     "composer",
     "local"
   ],


### PR DESCRIPTION
Love your module! Here is [jspm](http://jspm.io/) support.

jspm uses two configuration files. The namespace `jspm` inside `package.json` and and its own `config.js` file. The `config.js` is treated like a shrinkwrap file. Thus equal `config.js` => equal `jspm install` result ..... except: 

1. a dependency was added to the `package.json` but is missing in the `config.js`. Then jspm installs the additional vendor and writes it into the `config.js`

   => catched by: backup and restore the `config.js` in conjunction with the install directory

2. a path setting was changed in the `package.json`

   => catched by: include the `jspm` data from the `package.json` in the hash calculation

Supports package.json config:
* `jspm.directories.baseURL` => modifies vendor and config location
* `jspm.configFile` =>  modifies config location (and ignores baseURL)
* `jspm.directories.packages` =>  modifies vendor location (and ignores baseURL)

Off Topic: npm-cache could only restore the archived directory in the project root. I fixed that, so `web/jspm_packages` for a symfony2 directory structure is possible.