### PR TITLE
Atomic cache file write

### DIFF
--- a/cacheDependencyManagers/cacheDependencyManager.js
+++ b/cacheDependencyManagers/cacheDependencyManager.js
@@ -102,6 +102,8 @@ CacheDependencyManager.prototype.archiveDependencies = function (cacheDirectory,
   fs.mkdirsSync(cacheDirectory);
 
   var tmpName = tmp.tmpNameSync();
+  tmp.setGracefulCleanup();
+
   var dirDest = fsNode.createWriteStream(tmpName);
 
   function onError(error) {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "nomnom": "1.8.1",
     "shelljs": "0.5.3",
     "tar": "^2.2.1",
+    "tmp": "^0.0.28",
     "which": "^1.2.0"
   },
   "preferGlobal": true,


### PR DESCRIPTION
In multiprocess environments like some CI systems, some processes may try and read the cache file before another process has finished writing it to disk.

This change will introduce an atomic rename operation, where the file will get streamed to disk with a temporary file name, before finally being rewritten with the final file name once writes have finished.