### PR TITLE
uncompressed dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ npm-cache install bower npm	# install bower and npm components
 npm-cache install bower --allow-root composer --dry-run	# install bower with allow-root, and composer with --dry-run
 npm-cache install --cacheDirectory /home/cache/  bower 	# install components using /home/cache as cache directory
 npm-cache install --forceRefresh  bower	# force installing dependencies from package manager without cache
+npm-cache install --no-archive  npm	# installs dependencies and caches them without compressing
 npm-cache clean	# cleans out all cached files in cache directory
 ```
 

--- a/cacheDependencyManagers/cacheDependencyManager.js
+++ b/cacheDependencyManagers/cacheDependencyManager.js
@@ -6,7 +6,6 @@ var logger = require('../util/logger');
 var shell = require('shelljs');
 var which = require('which');
 var tar = require('tar');
-var fsNode = require('fs');
 var fstream = require('fstream');
 var md5 = require('md5');
 var tmp = require('tmp');
@@ -106,7 +105,7 @@ CacheDependencyManager.prototype.archiveDependencies = function (cacheDirectory,
   });
   tmp.setGracefulCleanup();
 
-  var dirDest = fsNode.createWriteStream(tmpName);
+  var dirDest = fs.createWriteStream(tmpName);
 
   function onError(error) {
     self.cacheLogError('error tar-ing ' + installedDirectory + ' :' + error);
@@ -131,17 +130,20 @@ CacheDependencyManager.prototype.archiveDependencies = function (cacheDirectory,
     }
   }
 
-  var packer = tar.Pack({ noProprietary: true })
-                  .on('error', onError)
-                  .on('end', onEnd);
+  var installedDirectoryStream = fstream.Reader({path: installedDirectory}).on('error', onError);
 
-  fstream.Reader({path: installedDirectory})
-         .on('error', onError)
-         .pipe(packer)
-         .pipe(dirDest);
+  if (this.config.noArchive) {
+    installedDirectoryStream = installedDirectoryStream.on('end', onEnd);
+  } else {
+    var packer = tar.Pack({ noProprietary: true })
+                    .on('error', onError)
+                    .on('end', onEnd);
+    installedDirectoryStream = installedDirectoryStream.pipe(packer)
+  }
+  installedDirectoryStream.pipe(fstream.Writer(cachePath));
 };
 
-CacheDependencyManager.prototype.extractDependencies = function (cachePath, callback) {
+CacheDependencyManager.prototype.installCachedDependencies = function (cachePath, compressedCacheExists, callback) {
   var self = this;
   var installDirectory = getAbsolutePath(this.config.installDirectory);
   var fileBackupDirectory = getFileBackupPath(installDirectory);
@@ -149,10 +151,10 @@ CacheDependencyManager.prototype.extractDependencies = function (cachePath, call
   this.cacheLogInfo('clearing installed dependencies at ' + installDirectory);
   fs.removeSync(installDirectory);
   this.cacheLogInfo('...cleared');
-  this.cacheLogInfo('extracting dependencies from ' + cachePath);
+  this.cacheLogInfo('retrieving dependencies from ' + cachePath);
 
   function onError(error) {
-    self.cacheLogError('Error extracting ' + cachePath + ': ' + error);
+    self.cacheLogError('Error retrieving ' + cachePath + ': ' + error);
     callback(error);
   }
   function onEnd() {
@@ -164,13 +166,20 @@ CacheDependencyManager.prototype.extractDependencies = function (cachePath, call
     callback();
   }
 
-  var extractor = tar.Extract({path: targetPath})
-                     .on('error', onError)
-                     .on('end', onEnd);
+  if (compressedCacheExists) {
+    var extractor = tar.Extract({path: targetPath})
+        .on('error', onError)
+        .on('end', onEnd);
 
-  fs.createReadStream(cachePath)
-    .on('error', onError)
-    .pipe(extractor);
+    fs.createReadStream(cachePath)
+        .on('error', onError)
+        .pipe(extractor);
+  } else {
+    fstream.Reader(cachePath)
+        .on('error', onError)
+        .on('end', onEnd)
+        .pipe(fstream.Writer(targetPath));
+  }
 };
 
 
@@ -204,25 +213,23 @@ CacheDependencyManager.prototype.loadDependencies = function (callback) {
   this.cacheLogInfo('hash of ' + this.config.configPath + ': ' + hash);
   // cachePath is absolute path to where local cache of dependencies is located
   var cacheDirectory = path.resolve(this.config.cacheDirectory, this.config.cliName, this.config.getCliVersion());
-  var cachePath = path.resolve(cacheDirectory, hash + '.tar.gz');
+  var cachePathArchive = path.resolve(cacheDirectory, hash + '.tar.gz');
+  var cachePathNotArchived = path.resolve(cacheDirectory, hash);
 
   // Check if local cache of dependencies exists
-  if (! this.config.forceRefresh && fs.existsSync(cachePath)) {
+  var cacheArchiveExists = fs.existsSync(cachePathArchive);
+  var cacheNotArchivedExists = fs.existsSync(cachePathNotArchived);
+  if (!this.config.forceRefresh && (cacheArchiveExists || cacheNotArchivedExists)) {
     this.cacheLogInfo('cache exists');
 
-    // Try to extract dependencies
-    this.extractDependencies(
-      cachePath,
-      function onExtracted (extractErr) {
-        if (extractErr) {
-          error = extractErr;
-        }
-        callback(error);
-      }
+    // Try to retrieve cached dependencies
+    this.installCachedDependencies(
+      cacheArchiveExists ? cachePathArchive : cachePathNotArchived,
+      cacheArchiveExists,
+      callback
     );
 
   } else { // install dependencies with CLI tool and cache
-
     // Try to install dependencies using package manager
     error = this.installDependencies();
     if (error !== null) {
@@ -231,15 +238,11 @@ CacheDependencyManager.prototype.loadDependencies = function (callback) {
     }
 
     // Try to archive newly installed dependencies
-    this.archiveDependencies(
-      cacheDirectory,
-      cachePath,
-      function onArchived (archiveError) {
-        if (archiveError) {
-          error = archiveError;
-        }
-        callback(error);
-      }
+    var cachePathWithInstalledDirectory = path.resolve(cachePathNotArchived, this.config.installDirectory);
+      this.archiveDependencies(
+      this.config.noArchive ? cachePathWithInstalledDirectory : cacheDirectory,
+      this.config.noArchive ? cachePathWithInstalledDirectory : cachePathArchive,
+      callback
     );
   }
 };

--- a/index.js
+++ b/index.js
@@ -47,6 +47,11 @@ var main = function () {
     abbr: 'c',
     help: 'directory where dependencies will be cached'
   });
+  parser.option('noArchive', {
+    abbr: 'd',
+    help: 'when installing a new dependency set, those dependencies will be stored uncompressed. This requires more disk space but notably increases performance',
+    flag: true
+  });
 
   parser.option('version', {
     abbr: 'v',
@@ -70,6 +75,7 @@ var main = function () {
     '\tnpm-cache install bower --allow-root composer --dry-run\t# install bower with allow-root, and composer with --dry-run',
     '\tnpm-cache install --cacheDirectory /home/cache/ bower \t# install components using /home/cache as cache directory',
     '\tnpm-cache install --forceRefresh  bower\t# force installing dependencies from package manager without cache',
+    '\tnpm-cache install --no-archive npm\t# do not compress/archive the cached dependencies',
     '\tnpm-cache clean\t# cleans out all cached files in cache directory',
     '\tnpm-cache hash\t# reports the current working hash'
   ];
@@ -105,6 +111,7 @@ var installDependencies = function (opts) {
       var managerConfig = require(availableManagers[managerName]);
       managerConfig.cacheDirectory = opts.cacheDirectory;
       managerConfig.forceRefresh = opts.forceRefresh;
+      managerConfig.noArchive = opts.noArchive;
       managerConfig.installOptions = managerArguments[managerName];
       var manager = new CacheDependencyManager(managerConfig);
       manager.loadDependencies(callback);


### PR DESCRIPTION
This PR resurrects #54, updated with the latest changes on master.

It adds a `--noArchive` option, which stores and retrieves the cached dependencies from a flat directory structure (instead of packing them in a `.tar.gz` file). This requires more disk space but notably increases performance.

Code by @klausbayrhammer.