### PR TITLE
Add option to clear invalid cache before install dependencies

### DIFF
--- a/cacheDependencyManagers/cacheDependencyManager.js
+++ b/cacheDependencyManagers/cacheDependencyManager.js
@@ -222,6 +222,17 @@ CacheDependencyManager.prototype.loadDependencies = function (callback) {
     );
 
   } else { // install dependencies with CLI tool and cache
+    // clear invalid cache before install dependencies
+    if (this.config.clearInvalidCache) {
+      var clearCommand = 'npm-cache clean --cacheDirectory ' + this.config.cacheDirectory;
+      this.cacheLogInfo('clearing invalid cache at ' + this.config.cacheDirectory);
+      if (shell.exec(clearCommand).code !== 0) {
+        error = 'error running ' + clearCommand;
+        this.cacheLogError(error);
+      } else {
+        this.cacheLogInfo('...cleared');
+      }
+    }
 
     // Try to install dependencies using package manager
     error = this.installDependencies();

--- a/index.js
+++ b/index.js
@@ -22,6 +22,12 @@ var main = function () {
       default: false,
       help: 'force installing dependencies from package manager without cache'
     })
+    .option('clearInvalidCache', {
+      abbr: 'i',
+      flag: true,
+      default: false,
+      help: 'clear invalid cache before install dependencies'
+    })
     .help('install specified dependencies');
 
   parser.command('clean')
@@ -70,6 +76,7 @@ var main = function () {
     '\tnpm-cache install bower --allow-root composer --dry-run\t# install bower with allow-root, and composer with --dry-run',
     '\tnpm-cache install --cacheDirectory /home/cache/ bower \t# install components using /home/cache as cache directory',
     '\tnpm-cache install --forceRefresh  bower\t# force installing dependencies from package manager without cache',
+    '\tnpm-cache install --clearInvalidCache  npm\t# clear invalid cache before install dependencies',
     '\tnpm-cache clean\t# cleans out all cached files in cache directory',
     '\tnpm-cache hash\t# reports the current working hash'
   ];
@@ -105,6 +112,7 @@ var installDependencies = function (opts) {
       var managerConfig = require(availableManagers[managerName]);
       managerConfig.cacheDirectory = opts.cacheDirectory;
       managerConfig.forceRefresh = opts.forceRefresh;
+      managerConfig.clearInvalidCache = opts.clearInvalidCache;
       managerConfig.installOptions = managerArguments[managerName];
       var manager = new CacheDependencyManager(managerConfig);
       manager.loadDependencies(callback);


### PR DESCRIPTION
Sometimes, we want to delete the invalid cache that was previously installed before installing the dependency to save disk space.
Add an option `clearInvalidCache` to allow users to decide whether or not to delete the invalid packets when they are installed.