### PR TITLE
Add option to clear invalid cache before install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@ npm-cache
 
 `npm-cache` is a command line utility that caches dependencies installed via `npm`, `bower`, `jspm` and `composer`.
 
-It is useful for build processes that run `[npm|bower|composer|jspm] install` every time as part of their 
+It is useful for build processes that run `[npm|bower|composer|jspm] install` every time as part of their
 build process. Since dependencies don't change often, this often means slower build times. `npm-cache`
-helps alleviate this problem by caching previously installed dependencies on the build machine. 
-`npm-cache` can be a drop-in replacement for any build script that runs `[npm|bower|composer|jspm] install`. 
+helps alleviate this problem by caching previously installed dependencies on the build machine.
+`npm-cache` can be a drop-in replacement for any build script that runs `[npm|bower|composer|jspm] install`.
 
 ## How it Works
 When you run `npm-cache install [npm|bower|jspm|composer]`, it first looks for `package.json`, `bower.json`,
 or `composer.json` in the current working directory depending on which dependency manager is requested.
-It then calculates the MD5 hash of the configuration file and looks for a filed named 
+It then calculates the MD5 hash of the configuration file and looks for a filed named
 <MD5 of config.json>.tar.gz in the cache directory ($HOME/.package_cache by default). If the file does not
 exist, `npm-cache` uses the system's installed dependency manager to install the dependencies. Once the
-dependencies are installed, `npm-cache` tars the newly downloaded dependencies and stores them in the 
+dependencies are installed, `npm-cache` tars the newly downloaded dependencies and stores them in the
 cache directory. The next time `npm-cache` runs and sees the same config file, it will find the tarball
 in the cache directory and untar the dependencies in the current working directory.
 
@@ -29,7 +29,7 @@ npm install -g npm-cache
 npm-cache install
 ```
 
-To specify arguments to each dependency manager, add the arguments after listing the dependency manager. 
+To specify arguments to each dependency manager, add the arguments after listing the dependency manager.
 
 For example, to install bower components with the `--allow-root` option, and composer with the `--dry-run` option:
 ```
@@ -44,6 +44,7 @@ npm-cache install bower npm	# install bower and npm components
 npm-cache install bower --allow-root composer --dry-run	# install bower with allow-root, and composer with --dry-run
 npm-cache install --cacheDirectory /home/cache/  bower 	# install components using /home/cache as cache directory
 npm-cache install --forceRefresh  bower	# force installing dependencies from package manager without cache
+npm-cache install --clearInvalidCache npm # clear invalid cache before install dependencies
 npm-cache clean	# cleans out all cached files in cache directory
 ```
 

--- a/cacheDependencyManagers/cacheDependencyManager.js
+++ b/cacheDependencyManagers/cacheDependencyManager.js
@@ -222,6 +222,17 @@ CacheDependencyManager.prototype.loadDependencies = function (callback) {
     );
 
   } else { // install dependencies with CLI tool and cache
+    // clear invalid cache before install dependencies
+    if (this.config.clearInvalidCache) {
+      var clearCommand = 'npm-cache clean --cacheDirectory ' + this.config.cacheDirectory;
+      this.cacheLogInfo('clearing invalid cache at ' + this.config.cacheDirectory);
+      if (shell.exec(clearCommand).code !== 0) {
+        error = 'error running ' + clearCommand;
+        this.cacheLogError(error);
+      } else {
+        this.cacheLogInfo('...cleared');
+      }
+    }
 
     // Try to install dependencies using package manager
     error = this.installDependencies();

--- a/index.js
+++ b/index.js
@@ -22,6 +22,12 @@ var main = function () {
       default: false,
       help: 'force installing dependencies from package manager without cache'
     })
+    .option('clearInvalidCache', {
+      abbr: 'i',
+      flag: true,
+      default: false,
+      help: 'clear invalid cache before install dependencies'
+    })
     .help('install specified dependencies');
 
   parser.command('clean')
@@ -70,6 +76,7 @@ var main = function () {
     '\tnpm-cache install bower --allow-root composer --dry-run\t# install bower with allow-root, and composer with --dry-run',
     '\tnpm-cache install --cacheDirectory /home/cache/ bower \t# install components using /home/cache as cache directory',
     '\tnpm-cache install --forceRefresh  bower\t# force installing dependencies from package manager without cache',
+    '\tnpm-cache install --clearInvalidCache  npm\t# clear invalid cache before install dependencies',
     '\tnpm-cache clean\t# cleans out all cached files in cache directory',
     '\tnpm-cache hash\t# reports the current working hash'
   ];
@@ -105,6 +112,7 @@ var installDependencies = function (opts) {
       var managerConfig = require(availableManagers[managerName]);
       managerConfig.cacheDirectory = opts.cacheDirectory;
       managerConfig.forceRefresh = opts.forceRefresh;
+      managerConfig.clearInvalidCache = opts.clearInvalidCache;
       managerConfig.installOptions = managerArguments[managerName];
       var manager = new CacheDependencyManager(managerConfig);
       manager.loadDependencies(callback);


### PR DESCRIPTION
Sometimes, we want to delete the invalid cache that was previously installed before installing the dependency to save disk space.

Add an option clearInvalidCache to allow users to decide whether or not to delete the invalid packets when they are installed.