### PR TITLE
Include process NODE_ENV in archive hash.

### DIFF
--- a/cacheDependencyManagers/npmConfig.js
+++ b/cacheDependencyManagers/npmConfig.js
@@ -25,7 +25,8 @@ function getFileHash(filePath) {
   var json = JSON.parse(fs.readFileSync(filePath));
   return md5(JSON.stringify({
     dependencies: json.dependencies,
-    devDependencies: json.devDependencies
+    devDependencies: json.devDependencies,
+    environment: process.env.NODE_ENV
   }));
 }
 


### PR DESCRIPTION
As the packages installed (devDependencies when _not_ on `production`) differ based on environment, the hash should include the process's environment.

Not doing this causes an issue with servers that have multiple environments running for one particular module. For example, I have `staging` and `production` installations of a repository on the same server, but run under different environments. If I install `production` before `staging`, the devDependencies will never be installed.
