### PR TITLE
Fix composer version detection

### DIFF
--- a/cacheDependencyManagers/composerConfig.js
+++ b/cacheDependencyManagers/composerConfig.js
@@ -51,7 +51,7 @@ var getCliVersion = function () {
   var versionString = shell.exec('composer --version', {silent: true}).output;
   // Example below:
   //    Composer version 1.0.0-alpha9 2014-12-07 17:15:20
-  var versionRegex = /^Composer version (\S+)/;
+  var versionRegex = /Composer version (\S+)/;
   var result = versionRegex.exec(versionString);
   if (result !== null) {
     version = result[1];


### PR DESCRIPTION
This is in case a warning is shown before the actual composer version. In the case where XDebug is installed the following error is shown :
```
Could not find composer version from version string: You are running composer with xdebug enabled. This has a major impact on runtime performance. See https://getcomposer.org/xdebug
Composer version 1.2.0 2016-07-19 01:28:52
```