### PR TITLE
#69 symlink cached modules copying mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,11 @@ var main = function () {
     help: 'when installing a new dependency set, those dependencies will be stored uncompressed. This requires more disk space but notably increases performance',
     flag: true
   });
+  parser.option('symlink', {
+    abbr: 's',
+    help: 'use symlink cached modules copying mode',
+    flag: true
+  });
 
   parser.option('version', {
     abbr: 'v',
@@ -112,6 +117,7 @@ var installDependencies = function (opts) {
       managerConfig.cacheDirectory = opts.cacheDirectory;
       managerConfig.forceRefresh = opts.forceRefresh;
       managerConfig.noArchive = opts.noArchive;
+      managerConfig.symlink = opts.symlink;
       managerConfig.installOptions = managerArguments[managerName];
       var manager = new CacheDependencyManager(managerConfig);
       manager.loadDependencies(callback);


### PR DESCRIPTION
`--symlink` cmd arg is added, it makes the `npm-cache` tool to symlink cached dependencies instead of the copying/unpacking. It does speed up dependencies delivering significantly with no extra disk I/O operations involved and so it might be helpful for CI build processes.

it's related to the https://github.com/swarajban/npm-cache/issues/69