### PR TITLE
#82 keep backward compatibility

### DIFF
--- a/cacheDependencyManagers/cacheDependencyManager.js
+++ b/cacheDependencyManagers/cacheDependencyManager.js
@@ -10,7 +10,7 @@ var fstream = require('fstream');
 var md5 = require('md5');
 var tmp = require('tmp');
 var _ = require('lodash');
-var zlib = require('zlib');
+// var zlib = require('zlib');
 
 var cacheVersion = '1';
 
@@ -140,8 +140,14 @@ CacheDependencyManager.prototype.archiveDependencies = function (cacheDirectory,
       .pipe(fstream.Writer({path: tmpName, type: 'Directory'}));
 
   } else {
-    tar.pack(installedDirectory)
-      .pipe(zlib.createGzip())
+    tar.pack(installedDirectory, {
+        map: function(header) {
+          // keep archive directory structure compatible with previously created archives, backward compatibility
+          header.name = self.config.installDirectory + '/' + header.name;
+          return header
+        }
+      })
+      //.pipe(zlib.createGzip())
       .pipe(fs.createWriteStream(tmpName))
       .on('error', onError)
       .on('finish', onEnd);
@@ -173,8 +179,8 @@ CacheDependencyManager.prototype.installCachedDependencies = function (cachePath
 
   if (compressedCacheExists) {
     fs.createReadStream(cachePath)
-      .pipe(zlib.createGunzip())
-      .pipe(tar.extract(installDirectory))
+      //.pipe(zlib.createGunzip())
+      .pipe(tar.extract(targetPath))
       .on('error', onError)
       .on('finish', onEnd);
   } else {


### PR DESCRIPTION
* fix broken 0.6.5 release problems

During a quick research I have not found a simple way to detect whether archive is gzipped or deflate and I'd prefer to not rely on `try ... catch` block detecting gzipped/deflate archive mode. So I just disabled gzipping for now, which makes archives compatible with previous versions, ie backward compatibility is supported.

Though further would be fine to enable gzipping, just need a way to read archive metadata (detect gzipped/deflate state).