### PR TITLE
Add support for using the system tar binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ npm-cache install bower --allow-root composer --dry-run	# install bower with all
 npm-cache install --cacheDirectory /home/cache/  bower 	# install components using /home/cache as cache directory
 npm-cache install --forceRefresh  bower	# force installing dependencies from package manager without cache
 npm-cache install --noArchive  npm	# installs dependencies and caches them without compressing
+npm-cache install --systemTar  npm	# use system tar binary for archving and extraction
 npm-cache clean	# cleans out all cached files in cache directory
 ```
 

--- a/index.js
+++ b/index.js
@@ -52,6 +52,11 @@ var main = function () {
     help: 'when installing a new dependency set, those dependencies will be stored uncompressed. This requires more disk space but notably increases performance',
     flag: true
   });
+  parser.option('systemTar', {
+    abbr: 's',
+    help: 'use system tar binary for archiving and extraction. This may increase the performance significantly.',
+    flag: true
+  });
 
   parser.option('version', {
     abbr: 'v',
@@ -76,6 +81,7 @@ var main = function () {
     '\tnpm-cache install --cacheDirectory /home/cache/ bower \t# install components using /home/cache as cache directory',
     '\tnpm-cache install --forceRefresh  bower\t# force installing dependencies from package manager without cache',
     '\tnpm-cache install --noArchive npm\t# do not compress/archive the cached dependencies',
+    '\tnpm-cache install --systemTar npm\t# use system tar binary for archving and extraction',
     '\tnpm-cache clean\t# cleans out all cached files in cache directory',
     '\tnpm-cache hash\t# reports the current working hash'
   ];
@@ -112,6 +118,7 @@ var installDependencies = function (opts) {
       managerConfig.cacheDirectory = opts.cacheDirectory;
       managerConfig.forceRefresh = opts.forceRefresh;
       managerConfig.noArchive = opts.noArchive;
+      managerConfig.systemTar = opts.systemTar;
       managerConfig.installOptions = managerArguments[managerName];
       var manager = new CacheDependencyManager(managerConfig);
       manager.loadDependencies(callback);


### PR DESCRIPTION
This adds an option (-s/--systemTar) which makes the archiving and
extracting use the system tar binary instead of tar-fs. This of course
requires that the system has tar installed, which is why it is added as
an option and not used by default.

In my experience, this increases the performance of the extraction by
around three to six times.