### PR TITLE
Npm cache flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-npm-cache
+npm-cache-flow
 =========
+npm-cache-flow is a fork of npm-cache from dashlane that supports arg flowthrough - only targetd version in this instance is npm your mileage may vary with the other packagers.
 
 `npm-cache` is a command line utility that caches dependencies installed via `npm`, `bower`, `jspm` and `composer`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
-npm-cache-flow
+npm-cache
 =========
-npm-cache-flow is a fork of npm-cache from dashlane that supports arg flowthrough - only targetd version in this instance is npm your mileage may vary with the other packagers.
+this npm-cache is a fork of npm-cache from dashlane that supports arg flowthrough and creates more robust hashes to avoid using wrong hash  tar - only the npm version is targeted in this instance...your mileage may vary with the other packagers.
+Hash is created by globbing devdependencies, dependencies and installOptions.
+
+this can also be used to create environment specific hash tarballs (on a build server)
+
+for instance
+`npm-cache install npm --production --bserver01`
+would create a different hash tarball than
+`npm-cache install npm --production --bserver02`
 
 `npm-cache` is a command line utility that caches dependencies installed via `npm`, `bower`, `jspm` and `composer`.
 
@@ -39,14 +47,16 @@ npm-cache install bower --allow-root composer --dry-run
 
 ## Examples
 ```bash
-npm-cache install	# try to install npm, bower, and composer components
-npm-cache install bower	# install only bower components
-npm-cache install bower npm	# install bower and npm components
-npm-cache install bower --allow-root composer --dry-run	# install bower with allow-root, and composer with --dry-run
-npm-cache install --cacheDirectory /home/cache/  bower 	# install components using /home/cache as cache directory
-npm-cache install --forceRefresh  bower	# force installing dependencies from package manager without cache
-npm-cache install --noArchive  npm	# installs dependencies and caches them without compressing
-npm-cache clean	# cleans out all cached files in cache directory
+   npm-cache install    # try to install npm, bower, and composer components
+   npm-cache install bower  # install only bower components
+   npm-cache install bower npm  # install bower and npm components
+   npm-cache install --cacheDirectory /home/cache/ bower    # install components using /home/cache as cache directory
+   npm-cache install --forceRefresh  bower  # force installing dependencies from package manager without cache
+   npm-cache install --noArchive npm    # do not compress/archive the cached dependencies
+   npm-cache install npm --production -msvs_version=2013    # add args to npm installer
+   npm-cache install npm --production -msvs_version=2013 bower --silent # add args to npm installer and bower
+   npm-cache clean  # cleans out all cached files in cache directory
+   npm-cache hash   # reports the current working hash
 ```
 
 ## Contributing

--- a/cacheDependencyManagers/cacheDependencyManager.js
+++ b/cacheDependencyManagers/cacheDependencyManager.js
@@ -36,6 +36,10 @@ CacheDependencyManager.prototype.cacheLogInfo = function (message) {
   logger.logInfo('[' + this.config.cliName + '] ' + message);
 };
 
+CacheDependencyManager.prototype.cacheLogRunning = function (message) {
+  logger.logRunning('[' + this.config.cliName + '] ' + message);
+};
+
 CacheDependencyManager.prototype.cacheLogError = function (error) {
   logger.logError('[' + this.config.cliName + '] ' + error);
 };
@@ -45,7 +49,7 @@ CacheDependencyManager.prototype.installDependencies = function () {
   var error = null;
   var installCommand = this.config.installCommand + ' ' + this.config.installOptions;
   installCommand = installCommand.trim();
-  this.cacheLogInfo('running [' + installCommand + ']...');
+  this.cacheLogRunning('running [' + installCommand + ']');
   if (shell.exec(installCommand).code !== 0) {
     error = 'error running ' + this.config.installCommand;
     this.cacheLogError(error);
@@ -192,10 +196,11 @@ CacheDependencyManager.prototype.loadDependencies = function (callback) {
 
   // Check if config file for dependency manager exists
   if (! fs.existsSync(this.config.configPath)) {
-    this.cacheLogInfo('Dependency config file ' + this.config.configPath + ' does not exist. Skipping install');
+    this.cacheLogInfo('No config file at:  ' + this.config.configPath + ' Skipping');
     callback(null);
     return;
   }
+
   this.cacheLogInfo('config file exists');
 
   // Check if package manger CLI is installed
@@ -211,7 +216,7 @@ CacheDependencyManager.prototype.loadDependencies = function (callback) {
   }
 
   // Get hash of dependency config file
-  var hash = this.config.getFileHash(this.config.configPath);
+  var hash = this.config.getFileHash(this.config.configPath, this.config.installOptions);
   hash = md5(cacheVersion + hash);
   this.cacheLogInfo('hash of ' + this.config.configPath + ': ' + hash);
   // cachePath is absolute path to where local cache of dependencies is located

--- a/cacheDependencyManagers/npmConfig.js
+++ b/cacheDependencyManagers/npmConfig.js
@@ -10,32 +10,48 @@ var logger = require('../util/logger');
 // Returns path to configuration file for npm. Uses
 // npm-shrinkwrap.json if it exists; otherwise,
 // defaults to package.json
-var getNpmConfigPath = function () {
-  var shrinkWrapPath = path.resolve(process.cwd(), 'npm-shrinkwrap.json');
-  var packagePath = path.resolve(process.cwd(), 'package.json');
-  if (fs.existsSync(shrinkWrapPath)) {
-    logger.logInfo('[npm] using npm-shrinkwrap.json instead of package.json');
-    return shrinkWrapPath;
-  } else {
-    return packagePath;
-  }
+var getNpmConfigPath = function() {
+		var shrinkWrapPath = path.resolve(process.cwd(), 'npm-shrinkwrap.json');
+		var packagePath = path.resolve(process.cwd(), 'package.json');
+		if (fs.existsSync(shrinkWrapPath)) {
+				logger.logInfo('[npm] using npm-shrinkwrap.json instead of package.json');
+				return shrinkWrapPath;
+		} else {
+				return packagePath;
+		}
 };
 
-function getFileHash(filePath) {
-  var json = JSON.parse(fs.readFileSync(filePath));
-  return md5(JSON.stringify({
-    dependencies: json.dependencies,
-    devDependencies: json.devDependencies
-  }));
+function getFileHash(filePath, installOptions) {
+		var json = JSON.parse(fs.readFileSync(filePath));
+		var toHash = {dependencies: json.dependencies};
+    //making the hash a bit more robust when using npm - not all package.jsons are perfect.
+
+		if (json.devDependencies) {
+				toHash.devDependencies = json.devDependencies;
+		}
+		if (json.repository && json.repository.url) {
+				toHash.repo = json.repository.url;
+		}
+
+		//important to add install options to this object a --production flag would cause a different node_modules structure.
+
+		if (installOptions) {
+				toHash.installOptions = installOptions;
+		}
+
+
+		var md5Hash = md5(JSON.stringify(toHash));
+
+		return md5Hash;
 }
 
 module.exports = {
-  cliName: 'npm',
-  getCliVersion: function getNpmVersion () {
-    return shell.exec('npm --version', {silent: true}).output.trim();
-  },
-  configPath: getNpmConfigPath(),
-  installDirectory: 'node_modules',
-  installCommand: 'npm install',
-  getFileHash: getFileHash
+		cliName: 'npm',
+		getCliVersion: function getNpmVersion() {
+				return shell.exec('npm --version', {silent: true}).output.trim();
+		},
+		configPath: getNpmConfigPath(),
+		installDirectory: 'node_modules',
+		installCommand: 'npm install',
+		getFileHash: getFileHash
 };

--- a/index.js
+++ b/index.js
@@ -72,10 +72,11 @@ var main = function () {
     '\tnpm-cache install\t# try to install npm, bower, and composer components',
     '\tnpm-cache install bower\t# install only bower components',
     '\tnpm-cache install bower npm\t# install bower and npm components',
-    '\tnpm-cache install bower --allow-root composer --dry-run\t# install bower with allow-root, and composer with --dry-run',
     '\tnpm-cache install --cacheDirectory /home/cache/ bower \t# install components using /home/cache as cache directory',
     '\tnpm-cache install --forceRefresh  bower\t# force installing dependencies from package manager without cache',
     '\tnpm-cache install --noArchive npm\t# do not compress/archive the cached dependencies',
+    '\tnpm-cache install npm --production -msvs_version=2013\t# add args to npm installer',
+    '\tnpm-cache install npm --production -msvs_version=2013 bower --silent\t# add args to npm installer and bower',
     '\tnpm-cache clean\t# cleans out all cached files in cache directory',
     '\tnpm-cache hash\t# reports the current working hash'
   ];
@@ -118,7 +119,7 @@ var installDependencies = function (opts) {
     },
     function onInstalled (error) {
       if (error === null) {
-        logger.logInfo('successfully installed all dependencies');
+        logger.logSuccess('successfully installed all dependencies');
         process.exit(0);
       } else {
         logger.logError('error installing dependencies');
@@ -145,7 +146,6 @@ var reportHash = function (opts) {
       managerConfig.cacheDirectory = opts.cacheDirectory;
 
       var hash = managerConfig.getFileHash(managerConfig.configPath);
-      console.log(hash);
     }
   );
 };

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var fs = require('fs-extra');
-var path = require('path');
+var path = require('upath');
 var parser = require('nomnom');
 var async = require('async');
 var rimraf = require('rimraf');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-cache",
-  "version": "0.1",
+  "version": "0.1.0",
   "description": "cache dependency manager installs to local machine - fork of npm-cache by swaraj - respects commandline args and deals with npm --production args etc.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "npm-cache",
-  "version": "0.6.5",
-  "description": "cache dependency manager installs to local machine",
+  "name": "npm-cache-flow",
+  "version": "0.6.6",
+  "description": "cache dependency manager installs to local machine - respects commandline args and deals with npm --production args etc.",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/swarajban/npm-cache.git"
+    "url": "git://github.com/klh/npm-cache.git"
   },
   "keywords": [
     "npm",
@@ -21,6 +21,10 @@
     {
       "name": "Aaron Nordyke",
       "email": "aaron.nordyke@gmail.com"
+    },
+        {
+      "name": "Klaus Hougesen",
+      "email": "Klaus.Hougesen@gmail.com"
     }
   ],
   "license": "MIT",
@@ -29,21 +33,23 @@
   },
   "homepage": "https://github.com/swarajban/npm-cache",
   "dependencies": {
-    "async": "1.5.0",
-    "fs-extra": "^0.26.2",
-    "fstream": "^1.0.8",
-    "lodash": "3.10.1",
-    "md5": "2.0.0",
+    "async": "2.1.4",
+    "cli-color": "^1.1.0",
+    "fs-extra": "2.0.0",
+    "fstream": "1.0.8",
+    "lodash": "4.17",
+    "log-symbols": "^1.0.2",
+    "md5": "2.2",
     "nomnom": "1.8.1",
     "rimraf": "^2.5.4",
-    "shelljs": "0.5.3",
-    "tar-fs": "1.14.0",
-    "tmp": "^0.0.28",
-    "which": "^1.2.0",
-    "upath":"^0.2.0"
+    "shelljs": "0.6",
+    "tar-fs": "1.15.0",
+    "tmp": "^0.0.31",
+    "upath": "^0.2.0",
+    "which": "^1.2.0"
   },
   "preferGlobal": true,
   "bin": {
-    "npm-cache": "index.js"
+    "npm-cache-flow": "index.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "shelljs": "0.5.3",
     "tar-fs": "1.14.0",
     "tmp": "^0.0.28",
-    "which": "^1.2.0"
+    "which": "^1.2.0",
+    "upath":"^0.2.0"
   },
   "preferGlobal": true,
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "npm-cache-flow",
-  "version": "0.6.6",
-  "description": "cache dependency manager installs to local machine - respects commandline args and deals with npm --production args etc.",
+  "name": "npm-cache",
+  "version": "0.1",
+  "description": "cache dependency manager installs to local machine - fork of npm-cache by swaraj - respects commandline args and deals with npm --production args etc.",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -50,6 +50,6 @@
   },
   "preferGlobal": true,
   "bin": {
-    "npm-cache-flow": "index.js"
+    "npm-cache": "index.js"
   }
 }

--- a/util/logger.js
+++ b/util/logger.js
@@ -1,10 +1,19 @@
 'use strict';
+var logSymbols = require('log-symbols'),
+		clic = require('cli-color');
 
 exports.logError = function (errorMessage) {
-  console.log('[npm-cache] [ERROR] ' + errorMessage);
+  console.log(logSymbols.error, errorMessage);
 };
 
 exports.logInfo = function (message) {
-  console.log('[npm-cache] [INFO] ' + message);
+  console.log(logSymbols.info, clic.blackBright( message));
 };
 
+exports.logSuccess = function (message) {
+  console.log(logSymbols.success,  clic.white.bgGreen(message));
+};
+
+exports.logRunning = function (message) {
+  console.log(logSymbols.success,  clic.white.bgCyan(message, "..."));
+};


### PR DESCRIPTION
added better support for variances of node_modules folder due to command line args such as --production. 

changing installOptions arg will invalidate caches, or at least flip between them - but this is the desired outcome (for instance on build servers)

added colors on cli-logs
changed readme to reflect changes