### PR TITLE
Feature/yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 npm-cache
 =========
 
-`npm-cache` is a command line utility that caches dependencies installed via `npm`, `bower`, `jspm` and `composer`.
+`npm-cache` is a command line utility that caches dependencies installed via `npm`, `bower`, `jspm`, `composer` and `yarn`.
 
-It is useful for build processes that run `[npm|bower|composer|jspm] install` every time as part of their 
+It is useful for build processes that run `[npm|bower|composer|jspm|yarn] install` every time as part of their 
 build process. Since dependencies don't change often, this often means slower build times. `npm-cache`
 helps alleviate this problem by caching previously installed dependencies on the build machine. 
-`npm-cache` can be a drop-in replacement for any build script that runs `[npm|bower|composer|jspm] install`. 
+`npm-cache` can be a drop-in replacement for any build script that runs `[npm|bower|composer|jspm|yarn] install`. 
 
 ## How it Works
-When you run `npm-cache install [npm|bower|jspm|composer]`, it first looks for `package.json`, `bower.json`,
-or `composer.json` in the current working directory depending on which dependency manager is requested.
+When you run `npm-cache install [npm|bower|jspm|composer|yarn]`, it first looks for `package.json`, `bower.json`, `composer.json` or 
+`yarn.lock` in the current working directory depending on which dependency manager is requested.
 It then calculates the MD5 hash of the configuration file and looks for a filed named 
 <MD5 of config.json>.tar.gz in the cache directory ($HOME/.package_cache by default). If the file does not
 exist, `npm-cache` uses the system's installed dependency manager to install the dependencies. Once the

--- a/cacheDependencyManagers/yarnConfig.js
+++ b/cacheDependencyManagers/yarnConfig.js
@@ -21,7 +21,6 @@ module.exports = {
     },
     configPath: 'yarn.lock',
     installDirectory: 'node_modules',
-    addToArchiveAndRestore: 'yarn.lock',
     installCommand: 'yarn',
     getFileHash: function() {
         return md5(getFileContents('yarn.lock'));

--- a/cacheDependencyManagers/yarnConfig.js
+++ b/cacheDependencyManagers/yarnConfig.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var path = require('path');
+var shell = require('shelljs');
+var fs = require('fs');
+var md5 = require('md5');
+
+/**
+ * @param {string} filename
+ * @returns {string}
+ */
+function getFileContents(filename) {
+    var file = path.resolve(process.cwd(), filename);
+    return fs.readFileSync(file);
+}
+
+module.exports = {
+    cliName: 'yarn',
+    getCliVersion: function () {
+        return shell.exec('yarn --version', {silent: true}).output.trim();
+    },
+    configPath: 'yarn.lock',
+    installDirectory: 'node_modules',
+    addToArchiveAndRestore: 'yarn.lock',
+    installCommand: 'yarn',
+    getFileHash: function() {
+        return md5(getFileContents('yarn.lock'));
+    }
+};


### PR DESCRIPTION
https://yarnpkg.com/ support. Yarn is pretty fast already. But if you require a binary like `node-sass` or `fsevents`, npm-cache still beats it. For the hash you just need the `yarn.lock` that it generates next to the `package.json`.

```bash
npm-cache install yarn
```