### PR TITLE
add package-lock.json support introducted by npm@5

### DIFF
--- a/cacheDependencyManagers/npmConfig.js
+++ b/cacheDependencyManagers/npmConfig.js
@@ -8,17 +8,24 @@ var logger = require('../util/logger');
 
 
 // Returns path to configuration file for npm. Uses
-// npm-shrinkwrap.json if it exists; otherwise,
-// defaults to package.json
+// - npm-shrinkwrap.json if it exists; otherwise,
+// - package-lock.json if it exists; otherwise,
+// - defaults to package.json
 var getNpmConfigPath = function () {
   var shrinkWrapPath = path.resolve(process.cwd(), 'npm-shrinkwrap.json');
-  var packagePath = path.resolve(process.cwd(), 'package.json');
   if (fs.existsSync(shrinkWrapPath)) {
     logger.logInfo('[npm] using npm-shrinkwrap.json instead of package.json');
     return shrinkWrapPath;
-  } else {
-    return packagePath;
   }
+  
+  var packageLockPath = path.resolve(process.cwd(), 'package-lock.json');
+  if (fs.existsSync(packageLockPath)) {
+    logger.logInfo('[npm] using package-lock.json instead of package.json');
+    return packageLockPath;
+  }
+
+  var packagePath = path.resolve(process.cwd(), 'package.json');
+  return packagePath;
 };
 
 function getFileHash(filePath) {


### PR DESCRIPTION
[npm@5 is here](http://blog.npmjs.org/post/161081169345/v500) and it generates a `package-lock.json` by default. It supersedes the package.json for `npm install`, so use that for npm-cache check.

You are still able to generate a `npm-shrinkwrap.json`, so that remains.

The checksum if npm install should be redone is generated by a single file. It is used if it exists in this priority:

npm-cache@0.6.5: `npm-shrinkwrap.json` > `package.json`
npm-cache@ThisPR: `npm-shrinkwrap.json` > `package-lock.json` > `package.json`