### PR TITLE
Fix npmConfig for lock versions 2 and 3

### DIFF
--- a/cacheDependencyManagers/npmConfig.js
+++ b/cacheDependencyManagers/npmConfig.js
@@ -39,6 +39,37 @@ var getNpmConfigPath = function () {
 
 function getFileHash(filePath) {
   var json = JSON.parse(fs.readFileSync(filePath));
+
+  // Detect if we are reading a package-lock.json file and retrieve the
+  // dependencies depending on the lockfile version. In version 1, no packages
+  // object. Version 2 and 3 have a packages object to describe the project's
+  // metadata, including its (dev) dependencies.
+  if (json.lockfileVersion) {
+    var lockfileVersion = json.lockfileVersion;
+    logger.logInfo(`Generating hash from package-lock.json version ${lockfileVersion}`);
+
+    switch (lockfileVersion) {
+      case 1:
+        return md5(JSON.stringify({
+          dependencies: json.dependencies,
+          devDependencies: json.devDependencies
+        }));
+      case 2:
+      case 3:
+        var packages = json.packages[""];
+
+        return md5(JSON.stringify({
+          dependencies: packages.dependencies,
+          devDependencies: packages.devDependencies
+        }));
+      default:
+        logger.logError('Unsupported lock file version. Open a pull request if you think it should be.');
+        return;
+    }
+  }
+
+  logger.logInfo(`Hash generated from package.json`);
+  
   return md5(JSON.stringify({
     dependencies: json.dependencies,
     devDependencies: json.devDependencies


### PR DESCRIPTION
The `getFileHash` function has been created or only tested against package-lock.json files with a lock version at 1. The version 2 introduced the `packages` object, which contains the project's metadata, including `dependencies` and `devDependencies`.

This commit fix the hash generation that was previously done on an empty string. The consequence was no cache invalidation since the hash was always the same in case of a lock version 2 or 3.

The hash generation can easily be tested by generating different package-lock.json file versions with the folowing command in an npm project: `npm i --lockfile-version 1 --package-lock-only`.